### PR TITLE
"type-is" dependency removed because koa already has content-negotiat…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const os = require('os')
-const is = require('type-is')
 const extract = require('./extract')
 
 module.exports = function (options = {}) {
@@ -9,7 +8,9 @@ module.exports = function (options = {}) {
   }
 
   return async (ctx, next) => {
-    if (!is(ctx.req, ['multipart'])) return next()
+    if (!ctx.is('multipart')) {
+      return next()
+    }
 
     try {
       let { files, fields } = await extract(ctx.req, dest, fnDestFilename, Object.assign({}, options))

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "append-field": "^1.0.0",
-    "busboy": "^0.2.14",
-    "type-is": "^1.6.15"
+    "busboy": "^0.2.14"
   }
 }


### PR DESCRIPTION
…ion helpers

[request.is(types...)](http://koajs.com/#request-is-types-)