### PR TITLE
Add support for google cloud functions

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -52,6 +52,10 @@ module.exports = function (req, dest, fnDestFilename, opts = {}) {
     busboy.on('filesLimit', () => reject(new Error('LIMIT_FILE_COUNT')))
     busboy.on('fieldsLimit', () => reject(new Error('LIMIT_FIELD_COUNT')))
 
-    req.pipe(busboy)
+    if (req.rawBody) {
+      busboy.end(req.rawBody)
+    } else {
+      req.pipe(busboy);
+    }
   })
 }


### PR DESCRIPTION
This PR makes it possible to use this module together with google cloud functions. The issue here was that the request object was being tampered with before the request hit this module. I updated `extract.js` with the following content:

```
if (req.rawBody) {
  busboy.end(req.rawBody)
} else {
  req.pipe(busboy)
}
```

as per suggestion from here: [busboy issue](https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/161)