### PR TITLE
Remove depends on vulnerable versions of busboy

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -8,8 +8,9 @@ module.exports = function (req, dest, fnDestFilename, opts = {}) {
     let files = []
     let fields = {}
 
-    let busboy = new Busboy(Object.assign({}, opts, {headers: req.headers}))
-    busboy.on('file', (fieldname, fileStream, filename, encoding, mimetype) => {
+    let busboy = Busboy(Object.assign({}, opts, {headers: req.headers}))
+    busboy.on('file', (fieldname, fileStream, info) => {
+      const { filename, encoding, mimeType } = info;
       if (!filename) return fileStream.resume()
 
       files.push(new Promise(function (resolve, reject) {
@@ -23,7 +24,7 @@ module.exports = function (req, dest, fnDestFilename, opts = {}) {
             rs.fieldname = fieldname
             rs.filename = filename
             rs.encoding = encoding
-            rs.mimetype = mimetype
+            rs.mimetype = mimeType
 
             resolve(rs)
           })

--- a/extract.js
+++ b/extract.js
@@ -19,7 +19,7 @@ module.exports = function (req, dest, fnDestFilename, opts = {}) {
 
         fileStream.pipe(fs.createWriteStream(tmpPath))
           .on('error', reject)
-          .on('finish', () => {
+          .on('close', () => {
             let rs = fs.createReadStream(tmpPath)
             rs.fieldname = fieldname
             rs.filename = filename
@@ -38,7 +38,7 @@ module.exports = function (req, dest, fnDestFilename, opts = {}) {
       appendField(fields, name, value)
     })
 
-    busboy.on('finish', () => {
+    busboy.on('close', () => {
       if (files.length) {
         Promise.all(files)
           .then(files => resolve({ fields, files }))

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "append-field": "^1.0.0",
-    "busboy": "^0.2.14"
+    "busboy": "^1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-busboy",
-  "version": "1.2.0",
+  "version": "1.6.0",
   "description": "Koa - Upload files with busboy",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@dominhhai @nervgh @christopherL91 Please apply request.

It fixes a security issue when running npm audit.

Example see here:
```shell
3 high severity vulnerabilities

    node_modules/koa-busboy
    Depends on vulnerable versions of busboy
    koa-busboy  *
  node_modules/busboy
  Depends on vulnerable versions of dicer
  busboy  <=0.3.1
node_modules/dicer
No fix available
Crash in HeaderParser in dicer - https://github.com/advisories/GHSA-wm7h-9275-46v2
Severity: high
dicer  *
```

The fix uses a newer version of busboy and make some changes to fix breaking changes see https://github.com/mscdex/busboy/issues/266

Best regards.
